### PR TITLE
initialize audio context only when it's not available

### DIFF
--- a/audio/static/js/recorder_object.js
+++ b/audio/static/js/recorder_object.js
@@ -32,8 +32,7 @@ function startRecording(cb) {
     window.AudioContext = window.AudioContext || window.webkitAudioContext;
     navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia;
     window.URL = window.URL || window.webkitURL;
-
-    audio_context = new AudioContext;
+    if(!audio_context) audio_context = new AudioContext;
     console.log('Audio context set up.');
     console.log('navigator.getUserMedia ' + (navigator.getUserMedia ? 'available.' : 'not present!'));
   } catch (e) {


### PR DESCRIPTION
this closes issue #85 
also targets safari on Mac OS on issue #116 

Disclaimer: I have tested only on MacOS and haven't tested on IOS, since I'm an android user.